### PR TITLE
Added missing content field on everything class

### DIFF
--- a/lib/everything.rb
+++ b/lib/everything.rb
@@ -4,16 +4,18 @@ class Everything
     attr_accessor :author
     attr_accessor :title
     attr_accessor :description
+    attr_accessor :content
     attr_accessor :url
     attr_accessor :urlToImage
     attr_accessor :publishedAt
 
-    def initialize(source, author, title, description, url, urlToImage, publishedAt)
+    def initialize(source, author, title, description, content, url, urlToImage, publishedAt)
         @id = source["id"]
         @name = source["name"]
         @author = author
         @title = title
         @description = description
+        @content = content
         @url = url
         @urlToImage = urlToImage
         @publishedAt = publishedAt

--- a/lib/news-api.rb
+++ b/lib/news-api.rb
@@ -10,7 +10,7 @@ class News
     BASE_URL = 'https://newsapi.org/' + VERSION + '/'
 
     def initialize(api_key)
-        @api_key = api_key 
+        @api_key = api_key
     end
 
     def get_top_headlines(**args)
@@ -80,7 +80,7 @@ class News
             data.push(
                 Everything.new(
                     a["source"], a["author"], a["title"],
-                    a["description"], a["url"],
+                    a["description"], a["content"], a["url"],
                     a["urlToImage"], a["publishedAt"]
                 )
             )


### PR DESCRIPTION
Based on the [news api doc](https://newsapi.org/docs/endpoints/everything), we should have a `content` field on `Everything`